### PR TITLE
Rewritten. Getting rid of Connect/Express dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ language: node_js
 node_js:
   - 'stable'
   - '5.0'
+  - '4.0'
+  - '0.12'
+  - '0.10'

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ render('path/or/name/of/my.tag', opts, function(rendered) {
 })
 ```
 
-In order to make the renderer to wait untill all of your asynchronous stuff will be completed, you need to run `this.asyncStart()` before your async calls and `this.asyncEnd()` after they are ready (or better see higher level approach below)
+In order to make the renderer to wait untill all of your asynchronous stuff will be completed, you need to run `this.asyncStart()` before your async calls and `this.asyncEnd()` after they are ready (or better see higher level approach below). You can use this functions as many times you want, for your every async call, but they must to always go together.
 
 ```html
 <some-component>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![NPM Version][npm-image]][npm-url]
 [![Build Status][travis-image]][travis-url]
 
-Synchronous/Asynchronous server-side rendering of RiotJS tags. Works well with nested tags and multiple async calls. Great test coverage
+Synchronous/Asynchronous server-side rendering of RiotJS tags. Works well with nested tags and multiple async calls.
 
 ## Installation
 
@@ -24,7 +24,7 @@ render('path/or/name/of/my.tag', opts, function(rendered) {
 })
 ```
 
-In order to make the renderer to wait untill all of your asynchronous stuff will be completed, you need to run `this.asyncStart()` before your async calls and `this.asyncEnd()` after they are ready (or better see higher level approach below). You can use this functions as many times you want, for your every async call, but they must to always go together.
+In order to make the renderer to wait untill all of your asynchronous stuff will be completed, you need to run `this.asyncStart()` before your async calls and `this.asyncEnd()` after they are ready (or better see higher level approach below). You can use this functions as many times you want (for your every async call), but they must to always go together.
 
 ```html
 <some-component>
@@ -55,7 +55,7 @@ riot.Tag.prototype.someAsyncFunction = function(callback) {
   setTimeout(() => {
     callback('Hello world!')
     this.asyncEnd()
-  }, 10)
+  }, 100)
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -24,8 +24,7 @@ function render(tag_path, opts, callback) {
     return _render(tag)
   } else {
     var tag = createAsyncTag(tag_path, opts, function() {
-      var rendered = _render(tag)
-      callback(rendered)
+      callback(_render(tag))
     })
     tag.mount()
   }
@@ -146,10 +145,10 @@ function withChildren(tag) {
  */
 
 function getChildrenTags(tag) {
-  var result = []
+  var result = [], child
 
   for (var tag_name in tag.tags) {
-    var child = tag.tags[tag_name]
+    child = tag.tags[tag_name]
 
     result.push(child)
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "riot-ssr",
-  "version": "0.1.0",
-  "description": "Synchronous and asynchronous server-side rendering of RiotJS tags for Connect/Express",
+  "version": "1.0.0",
+  "description": "Synchronous/Asynchronous server-side rendering of RiotJS tags",
   "main": "index.js",
   "scripts": {
     "test": "mocha test/specs.js"
   },
   "engines": {
-    "node": ">=5.0.0"
+    "node": ">=0.10.0"
   },
   "files": [
     "index.js"

--- a/test/specs.js
+++ b/test/specs.js
@@ -69,9 +69,8 @@ describe('riot-ssr', function() {
 
         render(long_running_tag, {}, function(result) {
           expect(result).to.equal('<long-running><p>ok</p></long-running>')
+          if (i === 10) done()
         })
-
-        if (i === 10) done()
 
       }, timeout)
     }

--- a/test/specs.js
+++ b/test/specs.js
@@ -1,45 +1,80 @@
-'use strict'
+var render = require('..')
+var expect = require('chai').expect
 
-const expect = require('chai').expect
-const riotSSR = require('..')
+var sync_tag = __dirname + '/tags/sync.js'
+var async_tag = __dirname + '/tags/async.js'
+var nested_tag = __dirname + '/tags/nested.js'
+var long_running_tag = __dirname + '/tags/long-running.js'
 
-const sync_tag_path = __dirname + '/tags/sync.js'
-const async_tag_path = __dirname + '/tags/async.js'
 
 describe('riot-ssr', function() {
+
   it('should render asynchronously', function(done) {
-    pretendServer(riotSSR(), function(req, res) {
-      res.riotSSR.renderAsync(async_tag_path, {}, function(rendered) {
-        expect(rendered).to.equal('<async><p>ok</p></async>')
-        done()
-      })
-    })
-  })
-
-  it('should render synchronous tag with `renderAsync`', function(done) {
-    pretendServer(riotSSR(), function(req, res) {
-      res.riotSSR.renderAsync(sync_tag_path, {}, function(rendered) {
-        expect(rendered).to.equal('<sync><p>ok</p></sync>')
-        done()
-      })
-    })
-  })
-
-  it('should render synchronous tag with `render`', function(done) {
-    pretendServer(riotSSR(), function(req, res) {
-      const rendered = res.riotSSR.render(sync_tag_path, {});
-      expect(rendered).to.equal('<sync><p>ok</p></sync>')
+    render(async_tag, {}, function(result) {
+      expect(result).to.equal('<async><p>ok</p></async>')
       done()
     })
   })
+
+  it('should render synchronously', function(done) {
+    var result = render(sync_tag, {})
+    expect(result).to.equal('<sync><p>ok</p></sync>')
+    done()
+  })
+
+  it('should render synchronously when a callback is given', function(done) {
+    render(sync_tag, {}, function(result) {
+      expect(result).to.equal('<sync><p>ok</p></sync>')
+      done()
+    })
+  })
+
+  it('should work with just a tag name given (instead of full path)', function(done) {
+    var result = render('sync', {})
+    expect(result).to.equal('<sync><p>ok</p></sync>')
+    done()
+  })
+
+  it('should allow to skip opts argument', function(done) {
+    var result = render(sync_tag)
+    expect(result).to.equal('<sync><p>ok</p></sync>')
+    done()
+  })
+
+  it('should allow to use callback as second argument', function(done) {
+    render(async_tag, function(result) {
+      expect(result).to.equal('<async><p>ok</p></async>')
+      done()
+    })
+  })
+
+  it('should support nested tags with multiple async calls', function(done) {
+    render(nested_tag, {}, function(result) {
+      expect(result).to.equal(
+        '<nested><div><sync><p>ok</p></sync><async><p>ok</p></async>ok</div></nested>'
+      )
+      done()
+    })
+  })
+
+  it('should handle long running simultaneous async calls', function(done) {
+    this.timeout(5000)
+
+    var timeout
+
+    for (var i = 0; i < 10; i++) {
+      timeout = i * 100
+
+      setTimeout(function() {
+
+        render(long_running_tag, {}, function(result) {
+          expect(result).to.equal('<long-running><p>ok</p></long-running>')
+        })
+
+        if (i === 10) done()
+
+      }, timeout)
+    }
+  })
+
 })
-
-
-function pretendServer(callback, callback2) {
-  var req = {}
-  var res = {}
-  var next = function() {}
-
-  callback(req, res, next)
-  callback2(req, res, next)
-}

--- a/test/specs.js
+++ b/test/specs.js
@@ -3,7 +3,9 @@ var expect = require('chai').expect
 
 var sync_tag = __dirname + '/tags/sync.js'
 var async_tag = __dirname + '/tags/async.js'
+var mount_tag = __dirname + '/tags/mount.js'
 var nested_tag = __dirname + '/tags/nested.js'
+var async_chain = __dirname + '/tags/async-chain.js'
 var long_running_tag = __dirname + '/tags/long-running.js'
 
 
@@ -11,39 +13,39 @@ describe('riot-ssr', function() {
 
   it('should render asynchronously', function(done) {
     render(async_tag, {}, function(result) {
-      expect(result).to.equal('<async><p>ok</p></async>')
+      expect(result).to.equal('<async>ok</async>')
       done()
     })
   })
 
   it('should render synchronously', function(done) {
     var result = render(sync_tag, {})
-    expect(result).to.equal('<sync><p>ok</p></sync>')
+    expect(result).to.equal('<sync>ok</sync>')
     done()
   })
 
   it('should render synchronously when a callback is given', function(done) {
     render(sync_tag, {}, function(result) {
-      expect(result).to.equal('<sync><p>ok</p></sync>')
+      expect(result).to.equal('<sync>ok</sync>')
       done()
     })
   })
 
   it('should work with just a tag name given (instead of full path)', function(done) {
     var result = render('sync', {})
-    expect(result).to.equal('<sync><p>ok</p></sync>')
+    expect(result).to.equal('<sync>ok</sync>')
     done()
   })
 
   it('should allow to skip opts argument', function(done) {
     var result = render(sync_tag)
-    expect(result).to.equal('<sync><p>ok</p></sync>')
+    expect(result).to.equal('<sync>ok</sync>')
     done()
   })
 
   it('should allow to use callback as second argument', function(done) {
     render(async_tag, function(result) {
-      expect(result).to.equal('<async><p>ok</p></async>')
+      expect(result).to.equal('<async>ok</async>')
       done()
     })
   })
@@ -51,7 +53,23 @@ describe('riot-ssr', function() {
   it('should support nested tags with multiple async calls', function(done) {
     render(nested_tag, {}, function(result) {
       expect(result).to.equal(
-        '<nested><div><sync><p>ok</p></sync><async><p>ok</p></async>ok</div></nested>'
+        '<nested><sync>ok</sync><async>ok</async>ok</nested>'
+      )
+      done()
+    })
+  })
+
+  it ('should wait until all async chain is finished', function(done) {
+    render(async_chain, {}, function(result) {
+      expect(result).to.equal('<async-chain>ok</async-chain>')
+      done()
+    })
+  })
+
+  it('should allow to `riot.mount()` a tag from inside of another tag', function(done) {
+    render(mount_tag, {}, function(result) {
+      expect(result).to.equal(
+        '<mount><div name="target" riot-tag="mount-child">ok<async>ok</async></div></mount>'
       )
       done()
     })
@@ -67,8 +85,9 @@ describe('riot-ssr', function() {
 
       setTimeout(function() {
 
-        render(long_running_tag, {}, function(result) {
-          expect(result).to.equal('<long-running><p>ok</p></long-running>')
+        var opts = { value: timeout }
+        render(long_running_tag, opts, function(result) {
+          expect(result).to.equal('<long-running>' + timeout + '</long-running>')
           if (i === 10) done()
         })
 

--- a/test/tags/async-chain.js
+++ b/test/tags/async-chain.js
@@ -1,21 +1,23 @@
 var riot = require('riot/riot.js')
 
 module.exports = riot.tag('async-chain', '{value}', function(opts) {
-  this.asyncStart()
-  this.asyncEnd()
+  var self = this
 
-  this.asyncStart()
-  this.asyncEnd()
+  self.asyncStart()
+  self.asyncEnd()
 
-  this.asyncStart()
-  setTimeout(() => {
-    this.asyncEnd()
+  self.asyncStart()
+  self.asyncEnd()
 
-    this.asyncStart()
-    setTimeout(() => {
-      this.value = 'ok'
-      this.update()
-      this.asyncEnd()
+  self.asyncStart()
+  setTimeout(function() {
+    self.asyncEnd()
+
+    self.asyncStart()
+    setTimeout(function() {
+      self.value = 'ok'
+      self.update()
+      self.asyncEnd()
     }, 10)
   }, 10)
 })

--- a/test/tags/async-chain.js
+++ b/test/tags/async-chain.js
@@ -1,0 +1,21 @@
+var riot = require('riot/riot.js')
+
+module.exports = riot.tag('async-chain', '{value}', function(opts) {
+  this.asyncStart()
+  this.asyncEnd()
+
+  this.asyncStart()
+  this.asyncEnd()
+
+  this.asyncStart()
+  setTimeout(() => {
+    this.asyncEnd()
+
+    this.asyncStart()
+    setTimeout(() => {
+      this.value = 'ok'
+      this.update()
+      this.asyncEnd()
+    }, 10)
+  }, 10)
+})

--- a/test/tags/async.js
+++ b/test/tags/async.js
@@ -1,6 +1,6 @@
 var riot = require('riot/riot.js')
 
-module.exports = riot.tag('async', '<p>{value}</p>', function(opts) {
+module.exports = riot.tag('async', '{value}', function(opts) {
   var self = this
   self.value = ''
   self.asyncStart()

--- a/test/tags/long-running.js
+++ b/test/tags/long-running.js
@@ -1,6 +1,6 @@
 var riot = require('riot/riot.js')
 
-module.exports = riot.tag('async', '<p>{value}</p>', function(opts) {
+module.exports = riot.tag('long-running', '<p>{value}</p>', function(opts) {
   var self = this
   self.value = ''
   self.asyncStart()
@@ -8,5 +8,5 @@ module.exports = riot.tag('async', '<p>{value}</p>', function(opts) {
     self.value = 'ok'
     self.update()
     self.asyncEnd()
-  }, 10)
+  }, 500)
 })

--- a/test/tags/long-running.js
+++ b/test/tags/long-running.js
@@ -1,11 +1,17 @@
 var riot = require('riot/riot.js')
 
-module.exports = riot.tag('long-running', '<p>{value}</p>', function(opts) {
+module.exports = riot.tag('long-running', '{value}', function(opts) {
+  // Riot v2.3.13 bug: https://github.com/riot/riot/issues/1517
+  if (Object.keys(opts).length === 0
+    && opts.__proto__ && Object.keys(opts.__proto__).length) {
+    opts = opts.__proto__
+  }
+
   var self = this
   self.value = ''
   self.asyncStart()
   setTimeout(function() {
-    self.value = 'ok'
+    self.value = opts.value || 'ok'
     self.update()
     self.asyncEnd()
   }, 500)

--- a/test/tags/mount.js
+++ b/test/tags/mount.js
@@ -1,0 +1,39 @@
+var riot = require('riot/riot.js')
+require('./async')
+
+module.exports = riot.tag('mount', '<div name="target"></div>', function(opts) {
+  // It's important that the child tag will contain a
+  // proper `parent` property which will reference to
+  // the current tag
+  var _opts = { parent: this }
+
+  var child = riot.mount(this.target, 'mount-child', _opts)[0]
+
+  // it's important to update the child tag when we
+  // assigning custom parent, otherways Riot may not
+  // compile expressions in HTML
+  child.update()
+})
+
+riot.tag('mount-child', '{value}<async></async>', function(opts) {
+  // Riot v2.3.13 bug: https://github.com/riot/riot/issues/1517
+  if (Object.keys(opts).length === 0
+    && opts.__proto__ && Object.keys(opts.__proto__).length) {
+    opts = opts.__proto__
+  }
+
+  var self = this
+
+  self.value = ''
+
+  // Before doing asyncStart, `this.parent` property
+  // should contain the proper parent tag
+  self.parent = opts.parent
+
+  self.asyncStart()
+  setTimeout(function() {
+    self.value = 'ok'
+    self.update()
+    self.asyncEnd()
+  }, 10)
+})

--- a/test/tags/nested.js
+++ b/test/tags/nested.js
@@ -1,0 +1,17 @@
+var riot = require('riot/riot.js')
+require('./sync')
+require('./async')
+
+module.exports = riot.tag('nested',
+  '<div><sync></sync><async></async>{value}</div>',
+  function(opts) {
+    var self = this
+    self.value = ''
+    self.asyncStart()
+    setTimeout(function() {
+      self.value = 'ok'
+      self.update()
+      self.asyncEnd()
+    }, 10)
+  }
+)

--- a/test/tags/nested.js
+++ b/test/tags/nested.js
@@ -2,8 +2,7 @@ var riot = require('riot/riot.js')
 require('./sync')
 require('./async')
 
-module.exports = riot.tag('nested',
-  '<div><sync></sync><async></async>{value}</div>',
+module.exports = riot.tag('nested', '<sync></sync><async></async>{value}',
   function(opts) {
     var self = this
     self.value = ''

--- a/test/tags/sync.js
+++ b/test/tags/sync.js
@@ -1,4 +1,4 @@
-const riot = require('riot/riot.js')
+var riot = require('riot/riot.js')
 
 module.exports = riot.tag('sync', '<p>{value}</p>', function(opts) {
   this.value = 'ok'

--- a/test/tags/sync.js
+++ b/test/tags/sync.js
@@ -1,5 +1,5 @@
 var riot = require('riot/riot.js')
 
-module.exports = riot.tag('sync', '<p>{value}</p>', function(opts) {
+module.exports = riot.tag('sync', '{value}', function(opts) {
   this.value = 'ok'
 })


### PR DESCRIPTION
Requires fixing of riot.js core files first before releasing
